### PR TITLE
Etheory patch gcc narrowing fix + MSVC support

### DIFF
--- a/fastapprox/src/fastonebigheader.h
+++ b/fastapprox/src/fastonebigheader.h
@@ -106,7 +106,7 @@ typedef __m128i v4si;
 
 #define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
 #define v2dil(x) ((const v4si) { (x), (x) })
-#define v4sil(x) v2dil((((unsigned long long) (x)) << 32) | (x))
+#define v4sil(x) v2dil((((long long) (x)) << 32) | (long long) (x))
 
 typedef union { v4sf f; float array[4]; } v4sfindexer;
 #define v4sf_index(_findx, _findi)      \

--- a/fastapprox/src/fastonebigheader.h
+++ b/fastapprox/src/fastonebigheader.h
@@ -104,8 +104,10 @@ typedef __m128i v4si;
 #define v4si_to_v4sf _mm_cvtepi32_ps
 #define v4sf_to_v4si _mm_cvttps_epi32
 
-#define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
-#define v2dil(x) ((const v4si) { (x), (x) })
+typedef const __m128 v4sf_const;
+typedef const __m128i v4si_const;
+#define v4sfl(x) (v4sf_const { (x), (x), (x), (x) })
+#define v2dil(x) (v4si_const { (x), (x) })
 #define v4sil(x) v2dil((((long long) (x)) << 32) | (long long) (x))
 
 typedef union { v4sf f; float array[4]; } v4sfindexer;

--- a/fastapprox/src/fastonebigheader.h
+++ b/fastapprox/src/fastonebigheader.h
@@ -117,6 +117,31 @@ typedef __m128i v4si;
 
   #define v4sfl(x) (const v4sf { (x), (x), (x), (x) })
   #define v4sil(x) (const v4si _MM_SETR_EPI32(x, x, x, x))
+
+  __forceinline const v4sf operator+(const v4sf& a, const v4sf& b) { return _mm_add_ps(a,b); }
+  __forceinline const v4sf operator-(const v4sf& a, const v4sf& b) { return _mm_sub_ps(a,b); }
+  __forceinline const v4sf operator/(const v4sf& a, const v4sf& b) { return _mm_div_ps(a,b); }
+  __forceinline const v4sf operator*(const v4sf& a, const v4sf& b) { return _mm_mul_ps(a,b); }
+
+  __forceinline const v4sf operator+(const v4sf& a) { return a; }
+  __forceinline const v4sf operator-(const v4sf& a) { return _mm_xor_ps(a, _mm_castsi128_ps(_mm_set1_epi32(0x80000000))); }
+
+  __forceinline const v4sf operator&(const v4sf& a, const v4sf& b) { return _mm_and_ps(a,b); }
+  __forceinline const v4sf operator|(const v4sf& a, const v4sf& b) { return _mm_or_ps(a,b); }
+  __forceinline const v4sf operator^(const v4sf& a, const v4sf& b) { return _mm_xor_ps(a,b); }
+
+  __forceinline const v4si operator&(const v4si& a, const v4si& b) { return _mm_and_si128(a,b); }
+  __forceinline const v4si operator|(const v4si& a, const v4si& b) { return _mm_or_si128(a,b); }
+  __forceinline const v4si operator^(const v4si& a, const v4si& b) { return _mm_xor_si128(a,b); }
+
+  __forceinline const v4sf operator+=(v4sf& a, const v4sf& b) { return a = a + b; }
+  __forceinline const v4sf operator-=(v4sf& a, const v4sf& b) { return a = a - b; }
+  __forceinline const v4sf operator*=(v4sf& a, const v4sf& b) { return a = a * b; }
+  __forceinline const v4sf operator/=(v4sf& a, const v4sf& b) { return a = a / b; }
+
+  __forceinline const v4si operator|=(v4si& a, const v4si& b) { return a = a | b; }
+  __forceinline const v4si operator&=(v4si& a, const v4si& b) { return a = a & b; }
+  __forceinline const v4si operator^=(v4si& a, const v4si& b) { return a = a ^ b; }
 #else
   #define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
   #define v2dil(x) ((const v4si) { (x), (x) })

--- a/fastapprox/src/fastonebigheader.h
+++ b/fastapprox/src/fastonebigheader.h
@@ -162,13 +162,17 @@ typedef union { v4si i; int array[4]; } v4siindexer;
   })
 
 typedef union { v4sf f; v4si i; } v4sfv4sipun;
-#define v4sf_fabs(x)                    \
+#if _MSC_VER && !__INTEL_COMPILER
+  #define v4sf_fabs(x) _mm_and_ps(x, _mm_castsi128_ps(_mm_set1_epi32(0x7fffffff)))
+#else
+  #define v4sf_fabs(x)                  \
   ({                                    \
      v4sfv4sipun vx;                    \
      vx.f = x;                          \
      vx.i &= v4sil (0x7FFFFFFF);        \
      vx.f;                              \
   })
+#endif
 
 #ifdef __cplusplus
 } // end namespace

--- a/fastapprox/src/fastonebigheader.h
+++ b/fastapprox/src/fastonebigheader.h
@@ -104,11 +104,24 @@ typedef __m128i v4si;
 #define v4si_to_v4sf _mm_cvtepi32_ps
 #define v4sf_to_v4si _mm_cvttps_epi32
 
-typedef const __m128 v4sf_const;
-typedef const __m128i v4si_const;
-#define v4sfl(x) (v4sf_const { (x), (x), (x), (x) })
-#define v2dil(x) (v4si_const { (x), (x) })
-#define v4sil(x) v2dil((((long long) (x)) << 32) | (long long) (x))
+#if _MSC_VER && !__INTEL_COMPILER
+  template <class T>
+  __forceinline char GetChar(T value, size_t index) { return ((char*)&value)[index]; }
+
+  #define AS_4CHARS(a) \
+      GetChar(int32_t(a), 0), GetChar(int32_t(a), 1), \
+      GetChar(int32_t(a), 2), GetChar(int32_t(a), 3)
+
+  #define _MM_SETR_EPI32(a0, a1, a2, a3) \
+      { AS_4CHARS(a0), AS_4CHARS(a1), AS_4CHARS(a2), AS_4CHARS(a3) }
+
+  #define v4sfl(x) (const v4sf { (x), (x), (x), (x) })
+  #define v4sil(x) (const v4si _MM_SETR_EPI32(x, x, x, x))
+#else
+  #define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
+  #define v2dil(x) ((const v4si) { (x), (x) })
+  #define v4sil(x) v2dil((((long long) (x)) << 32) | (long long) (x))
+#endif
 
 typedef union { v4sf f; float array[4]; } v4sfindexer;
 #define v4sf_index(_findx, _findi)      \

--- a/fastapprox/src/sse.h
+++ b/fastapprox/src/sse.h
@@ -55,11 +55,24 @@ typedef __m128i v4si;
 #define v4si_to_v4sf _mm_cvtepi32_ps
 #define v4sf_to_v4si _mm_cvttps_epi32
 
-typedef const __m128 v4sf_const;
-typedef const __m128i v4si_const;
-#define v4sfl(x) (v4sf_const { (x), (x), (x), (x) })
-#define v2dil(x) (v4si_const { (x), (x) })
-#define v4sil(x) v2dil((((long long) (x)) << 32) | (long long) (x))
+#if _MSC_VER && !__INTEL_COMPILER
+  template <class T>
+  __forceinline char GetChar(T value, size_t index) { return ((char*)&value)[index]; }
+
+  #define AS_4CHARS(a) \
+      GetChar(int32_t(a), 0), GetChar(int32_t(a), 1), \
+      GetChar(int32_t(a), 2), GetChar(int32_t(a), 3)
+
+  #define _MM_SETR_EPI32(a0, a1, a2, a3) \
+      { AS_4CHARS(a0), AS_4CHARS(a1), AS_4CHARS(a2), AS_4CHARS(a3) }
+
+  #define v4sfl(x) (const v4sf { (x), (x), (x), (x) })
+  #define v4sil(x) (const v4si _MM_SETR_EPI32(x, x, x, x))
+#else
+  #define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
+  #define v2dil(x) ((const v4si) { (x), (x) })
+  #define v4sil(x) v2dil((((long long) (x)) << 32) | (long long) (x))
+#endif
 
 typedef union { v4sf f; float array[4]; } v4sfindexer;
 #define v4sf_index(_findx, _findi)      \

--- a/fastapprox/src/sse.h
+++ b/fastapprox/src/sse.h
@@ -68,6 +68,31 @@ typedef __m128i v4si;
 
   #define v4sfl(x) (const v4sf { (x), (x), (x), (x) })
   #define v4sil(x) (const v4si _MM_SETR_EPI32(x, x, x, x))
+
+  __forceinline const v4sf operator+(const v4sf& a, const v4sf& b) { return _mm_add_ps(a,b); }
+  __forceinline const v4sf operator-(const v4sf& a, const v4sf& b) { return _mm_sub_ps(a,b); }
+  __forceinline const v4sf operator/(const v4sf& a, const v4sf& b) { return _mm_div_ps(a,b); }
+  __forceinline const v4sf operator*(const v4sf& a, const v4sf& b) { return _mm_mul_ps(a,b); }
+
+  __forceinline const v4sf operator+(const v4sf& a) { return a; }
+  __forceinline const v4sf operator-(const v4sf& a) { return _mm_xor_ps(a, _mm_castsi128_ps(_mm_set1_epi32(0x80000000))); }
+
+  __forceinline const v4sf operator&(const v4sf& a, const v4sf& b) { return _mm_and_ps(a,b); }
+  __forceinline const v4sf operator|(const v4sf& a, const v4sf& b) { return _mm_or_ps(a,b); }
+  __forceinline const v4sf operator^(const v4sf& a, const v4sf& b) { return _mm_xor_ps(a,b); }
+
+  __forceinline const v4si operator&(const v4si& a, const v4si& b) { return _mm_and_si128(a,b); }
+  __forceinline const v4si operator|(const v4si& a, const v4si& b) { return _mm_or_si128(a,b); }
+  __forceinline const v4si operator^(const v4si& a, const v4si& b) { return _mm_xor_si128(a,b); }
+
+  __forceinline const v4sf operator+=(v4sf& a, const v4sf& b) { return a = a + b; }
+  __forceinline const v4sf operator-=(v4sf& a, const v4sf& b) { return a = a - b; }
+  __forceinline const v4sf operator*=(v4sf& a, const v4sf& b) { return a = a * b; }
+  __forceinline const v4sf operator/=(v4sf& a, const v4sf& b) { return a = a / b; }
+
+  __forceinline const v4si operator|=(v4si& a, const v4si& b) { return a = a | b; }
+  __forceinline const v4si operator&=(v4si& a, const v4si& b) { return a = a & b; }
+  __forceinline const v4si operator^=(v4si& a, const v4si& b) { return a = a ^ b; }
 #else
   #define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
   #define v2dil(x) ((const v4si) { (x), (x) })

--- a/fastapprox/src/sse.h
+++ b/fastapprox/src/sse.h
@@ -57,7 +57,7 @@ typedef __m128i v4si;
 
 #define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
 #define v2dil(x) ((const v4si) { (x), (x) })
-#define v4sil(x) v2dil((((unsigned long long) (x)) << 32) | (x))
+#define v4sil(x) v2dil((((long long) (x)) << 32) | (long long) (x))
 
 typedef union { v4sf f; float array[4]; } v4sfindexer;
 #define v4sf_index(_findx, _findi)      \

--- a/fastapprox/src/sse.h
+++ b/fastapprox/src/sse.h
@@ -113,13 +113,17 @@ typedef union { v4si i; int array[4]; } v4siindexer;
   })
 
 typedef union { v4sf f; v4si i; } v4sfv4sipun;
-#define v4sf_fabs(x)                    \
+#if _MSC_VER && !__INTEL_COMPILER
+  #define v4sf_fabs(x) _mm_and_ps(x, _mm_castsi128_ps(_mm_set1_epi32(0x7fffffff)))
+#else
+  #define v4sf_fabs(x)                  \
   ({                                    \
      v4sfv4sipun vx;                    \
      vx.f = x;                          \
      vx.i &= v4sil (0x7FFFFFFF);        \
      vx.f;                              \
   })
+#endif
 
 #ifdef __cplusplus
 } // end namespace

--- a/fastapprox/src/sse.h
+++ b/fastapprox/src/sse.h
@@ -55,8 +55,10 @@ typedef __m128i v4si;
 #define v4si_to_v4sf _mm_cvtepi32_ps
 #define v4sf_to_v4si _mm_cvttps_epi32
 
-#define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
-#define v2dil(x) ((const v4si) { (x), (x) })
+typedef const __m128 v4sf_const;
+typedef const __m128i v4si_const;
+#define v4sfl(x) (v4sf_const { (x), (x), (x), (x) })
+#define v2dil(x) (v4si_const { (x), (x) })
 #define v4sil(x) v2dil((((long long) (x)) << 32) | (long long) (x))
 
 typedef union { v4sf f; float array[4]; } v4sfindexer;


### PR DESCRIPTION
The previous definition of v4sil was trying to cast to a 64bit type, but not exactly matching the expected underlying type (long long).

Under c++11, this fails to compile with a narrowing warning.
i.e. in gcc when using the flags "-std=c++11 -Wnarrowing"

By casting to a "long long" instead of "unsigned long long" above, we match the type of the underlying definition, and also the v2dil cast then work correctly to widen the 2 64bit type to the expected final 128bit type.

- Also added support for MSVC 2015+